### PR TITLE
Minor fixes in docs.

### DIFF
--- a/lib/prometheus/metric.ex
+++ b/lib/prometheus/metric.ex
@@ -7,20 +7,22 @@ defmodule Prometheus.Metric do
   accessible without `Prometheus.Metric` prefix.
 
   Allows to automatically setup metrics with
-  `@<type`> attributes. Metrics will be declared in
+  `@<type>` attributes. Metrics will be declared in
   the `@on_load` callback. If the module already
-  has `@on_laod` callback, metrics will be declared
+  has `@on_load` callback, metrics will be declared
   iff the callback returns `:ok`.
 
-     iex(1)> defmodule MyCoolModule do
-     ...(1)>   use Prometheus.Metric
-     ...(1)>
-     ...(1)>   @counter name: :test_counter3, labels: [], help: "qwe"
-     ...(1)> end
-     iex(2)> require Prometheus.Metric.Counter
-     Prometheus.Metric.Counter
-     iex(3)> Prometheus.Metric.Counter.value(:test_counter3)
-     0
+  Example:
+
+      iex(1)> defmodule MyCoolModule do
+      ...(1)>   use Prometheus.Metric
+      ...(1)>
+      ...(1)>   @counter name: :test_counter3, labels: [], help: "qwe"
+      ...(1)> end
+      iex(2)> require Prometheus.Metric.Counter
+      Prometheus.Metric.Counter
+      iex(3)> Prometheus.Metric.Counter.value(:test_counter3)
+      0
 
   """
 

--- a/lib/prometheus/metric/histogram.ex
+++ b/lib/prometheus/metric/histogram.ex
@@ -10,9 +10,9 @@ defmodule Prometheus.Metric.Histogram do
   Histogram expects `buckets` key in a metric spec. Buckets can be:
    - a list of numbers in increasing order;
    - one of the generate specs (shortcuts for `Prometheus.Buckets` macros)
-       - :default;
-       - {:linear, start, step, count};
-       - {:exponential, start, step, count}.
+       - `:default`;
+       - `{:linear, start, step, count}`;
+       - `{:exponential, start, step, count}`.
 
   Example:
 


### PR DESCRIPTION
Minor fixes in doc Markdown.

- Prometheus.Metric doc indent fixed to format as code
- Format Prometheus.Metrics.Histogram bucket generate specs as code