### PR TITLE
Add parenthesis around one assert in Gauge test

### DIFF
--- a/test/metric/gauge_test.exs
+++ b/test/metric/gauge_test.exs
@@ -247,7 +247,7 @@ defmodule Prometheus.GaugeTest do
     Gauge.dec(spec)
     Gauge.dec(spec, 3.5)
 
-    assert -8.5 == Gauge.value(spec)
+    assert (-8.5 == Gauge.value(spec))
 
     Gauge.reset(spec)
 


### PR DESCRIPTION
The parenthesis should make the Credo checks pass in CI.