### PR TITLE
Support Elixir 1.7/OTP 21 __STACKTRACE__ macro

### DIFF
--- a/lib/prometheus/error.ex
+++ b/lib/prometheus/error.ex
@@ -213,7 +213,17 @@ defmodule Prometheus.Error do
       try do
         unquote(block)
       rescue
-        e in ErlangError -> reraise Prometheus.Error.normalize(e), System.stacktrace()
+        e in ErlangError ->
+          reraise(
+            Prometheus.Error.normalize(e),
+            unquote(
+              if macro_exported?(Kernel.SpecialForms, :__STACKTRACE__, 0) do
+                quote(do: __STACKTRACE__)
+              else
+                quote(do: System.stacktrace())
+              end
+            )
+          )
       end
     end
   end

--- a/lib/prometheus/metric/counter.ex
+++ b/lib/prometheus/metric/counter.ex
@@ -143,7 +143,15 @@ defmodule Prometheus.Metric.Counter do
               unquote(block)
             rescue
               e in unquote(exception) ->
-                stacktrace = System.stacktrace()
+                stacktrace =
+                  unquote(
+                    if macro_exported?(Kernel.SpecialForms, :__STACKTRACE__, 0) do
+                      quote(do: __STACKTRACE__)
+                    else
+                      quote(do: System.stacktrace())
+                    end
+                  )
+
                 {registry, name, labels} = Prometheus.Metric.parse_spec(unquote(spec))
                 :prometheus_counter.inc(registry, name, labels, 1)
                 reraise(e, stacktrace)


### PR DESCRIPTION
`rescue` clauses should use the more efficient `__STACKTRACE__` macro when possible on Elixir 1.7.